### PR TITLE
New items and appraisal data from MagTools Inventory logs.

### DIFF
--- a/Database/4-CoreUpdates/updates.txt
+++ b/Database/4-CoreUpdates/updates.txt
@@ -1,3 +1,6 @@
+8/13/2017
+- Added items and missing data derived from MagTools Inventory logs
+
 6/25/2017
 --------
 - Updated 01-ClothingBase - 976 to 1143 records


### PR DESCRIPTION
Note - armor palette info currently not included for new items (but clothing table info is). I'll be manually going through these and adding in where possible at a later date.